### PR TITLE
OW v5.3: Per Player Options try 2

### DIFF
--- a/worlds/manual_outerwilds_nicopopxd/data/game.json
+++ b/worlds/manual_outerwilds_nicopopxd/data/game.json
@@ -3,5 +3,5 @@
     "creator": "Nicopopxd",
 
     "filler_item_name": "Quantum dust",
-    "version": "5.2.0"
+    "version": "5.3.0"
 }

--- a/worlds/manual_outerwilds_nicopopxd/data/items.json
+++ b/worlds/manual_outerwilds_nicopopxd/data/items.json
@@ -111,7 +111,7 @@
     },
     {
         "name": "Musical Instrument",
-        "count": 6,
+        "count": 7,
         "category": [ "Bonus", "2a Not Trap" ]
     },
     {

--- a/worlds/manual_outerwilds_nicopopxd/hooks/World.py
+++ b/worlds/manual_outerwilds_nicopopxd/hooks/World.py
@@ -25,7 +25,6 @@ from ..Helpers import is_option_enabled, get_option_value
 logger = logging.getLogger()
 removedPlacedItems = {}
 removedPlacedItemsCategory = {}
-changedItemsCount = {}
 OWMiscData = {}
 """Miscellaneous shared data"""
 OWMiscData["KnownPlayers"] = []


### PR DESCRIPTION
I swear it work this time ;)
## What is this fixing or adding?
- item count were shared between all player
- regrouped all the player's option in a dict so the rando only change their value once
- if multiple player in a row uses the same setting some code is skipped on
   every player after the first with X settings as long as the settings stay the same