### PR TITLE
OW v5.5: Minor changes include the Manual fixes and minor tweaks to logic

### DIFF
--- a/worlds/manual_outerwilds_nicopopxd/Locations.py
+++ b/worlds/manual_outerwilds_nicopopxd/Locations.py
@@ -36,8 +36,8 @@ location_table.append({
     "id": count + 1,
     "name": "__Manual Game Complete__",
     "region": custom_victory_location["region"] if "region" in custom_victory_location else "Manual",
-    "requires": custom_victory_location["requires"] if "requires" in custom_victory_location else [],
-    "category": custom_victory_location["category"] if "category" in custom_victory_location else ["(no category)"]
+    "requires": custom_victory_location["requires"] if "requires" in custom_victory_location else []
+    # "category": custom_victory_location["category"] if "category" in custom_victory_location else []
 })
 
 location_id_to_name = {}

--- a/worlds/manual_outerwilds_nicopopxd/Rules.py
+++ b/worlds/manual_outerwilds_nicopopxd/Rules.py
@@ -28,7 +28,7 @@ def infix_to_postfix(expr, location):
         while stack:
             postfix += stack.pop()
     except Exception:
-        raise KeyError("Invalid logic format for location/region {}.".format(location)) 
+        raise KeyError("Invalid logic format for location/region {}.".format(location))
     return postfix
 
 
@@ -52,8 +52,8 @@ def evaluate_postfix(expr, location):
                 op = stack.pop()
                 stack.append(not op)
     except Exception:
-        raise KeyError("Invalid logic format for location/region {}.".format(location)) 
-    
+        raise KeyError("Invalid logic format for location/region {}.".format(location))
+
     if len(stack) != 1:
         raise KeyError("Invalid logic format for location/region {}.".format(location))
     return stack.pop()
@@ -88,12 +88,12 @@ def set_rules(base: World, world: MultiWorld, player: int):
                 category_items = [item["name"] for item in base.item_name_to_item.values() if "category" in item and item_name in item["category"]]
 
                 for category_item in category_items:
-                    total += state.item_count(category_item, player)
+                    total += state.count(category_item, player)
 
                     if total >= item_count:
                         requires_list = requires_list.replace(item_base, "1")
             elif require_type == 'item':
-                total = state.item_count(item_name, player)
+                total = state.count(item_name, player)
 
                 if total >= item_count:
                     requires_list = requires_list.replace(item_base, "1")
@@ -116,7 +116,7 @@ def set_rules(base: World, world: MultiWorld, player: int):
             if (isinstance(item, dict) and "or" in item and isinstance(item["or"], list)) or (isinstance(item, list)):
                 canAccessOr = True
                 or_items = item
-                
+
                 if isinstance(item, dict):
                     or_items = item["or"]
 
@@ -154,31 +154,31 @@ def set_rules(base: World, world: MultiWorld, player: int):
         # if it's not a usable object of some sort, default to true
         if not area:
             return True
-        
+
         # don't require the "requires" key for locations and regions if they don't need to use it
         if "requires" not in area.keys():
             return True
-        
+
         if isinstance(area["requires"], str):
             return checkRequireStringForArea(state, area)
         else:  # item access is in dict form
             return checkRequireDictForArea(state, area)
-    
+
     # Region access rules
     for region in regionMap.keys():
         if region != "Menu":
             for exitRegion in world.get_region(region, player).exits:
                 def fullRegionCheck(state, region=regionMap[region]):
                     return fullLocationOrRegionCheck(state, region)
-                
-                set_rule(world.get_entrance(exitRegion.name, player), fullRegionCheck)    
+
+                set_rule(world.get_entrance(exitRegion.name, player), fullRegionCheck)
 
     # Location access rules
     for location in base.location_table:
         locFromWorld = world.get_location(location["name"], player)
 
         locationRegion = regionMap[location["region"]] if "region" in location else None
-        
+
         if "requires" in location: # Location has requires, check them alongside the region requires
             def checkBothLocationAndRegion(state, location=location, region=locationRegion):
                 locationCheck = fullLocationOrRegionCheck(state, location)
@@ -188,17 +188,17 @@ def set_rules(base: World, world: MultiWorld, player: int):
                     regionCheck = fullLocationOrRegionCheck(state, region)
 
                 return locationCheck and regionCheck
-            
+
             set_rule(locFromWorld, checkBothLocationAndRegion)
         elif "region" in location: # Only region access required, check the location's region's requires
             def fullRegionCheck(state, region=locationRegion):
                 return fullLocationOrRegionCheck(state, region)
-            
+
             set_rule(locFromWorld, fullRegionCheck)
         else: # No location region and no location requires? It's accessible.
             def allRegionsAccessible(state):
                 return True
-            
+
             set_rule(locFromWorld, allRegionsAccessible)
 
     # Victory requirement

--- a/worlds/manual_outerwilds_nicopopxd/__init__.py
+++ b/worlds/manual_outerwilds_nicopopxd/__init__.py
@@ -4,7 +4,7 @@ import logging
 import random
 import json
 
-from .Data import item_table, progressive_item_table, location_table
+from .Data import item_table, progressive_item_table, location_table, region_table
 from .Game import game_name, filler_item_name, starting_items
 from .Locations import location_id_to_name, location_name_to_id, location_name_to_location
 from .Items import item_id_to_name, item_name_to_id, item_name_to_item, advancement_item_names
@@ -84,13 +84,13 @@ class ManualWorld(World):
     required_client_version = (0, 3, 4)
 
     # These properties are set from the imports of the same name above.
-    item_table = copy(item_table)
-    progressive_item_table = copy(progressive_item_table)
+    item_table = item_table
+    progressive_item_table = progressive_item_table
     item_id_to_name = item_id_to_name
     item_name_to_id = item_name_to_id
     item_name_to_item = item_name_to_item
     advancement_item_names = advancement_item_names
-    location_table = copy(location_table) # this is likely imported from Data instead of Locations because the Game Complete location should not be in here, but is used for lookups
+    location_table = location_table # this is likely imported from Data instead of Locations because the Game Complete location should not be in here, but is used for lookups
     location_id_to_name = location_id_to_name
     location_name_to_id = location_name_to_id
     location_name_to_location = location_name_to_location
@@ -180,7 +180,7 @@ class ManualWorld(World):
         logger.debug(f"Extras: {extras}")
 
         if extras > 0:
-            for i in range(0, extras):
+            for _ in range(0, extras):
                 extra_item = self.create_item(filler_item_name)
                 pool.append(extra_item)
 
@@ -286,6 +286,10 @@ class ManualWorld(World):
             "game": self.game,
             'player_name': self.multiworld.get_player_name(self.player),
             'player_id': self.player,
+            'items': self.item_name_to_item,
+            'locations': self.location_name_to_location,
+            # todo: extract connections out of mutliworld.get_regions() instead, in case hooks have modified the regions.
+            'regions': region_table,
         }
 
     def generate_output(self, output_directory: str):
@@ -293,3 +297,4 @@ class ManualWorld(World):
         filename = f"{self.multiworld.get_out_file_name_base(self.player)}.apmanual"
         with open(os.path.join(output_directory, filename), 'wb') as f:
             f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
+

--- a/worlds/manual_outerwilds_nicopopxd/__init__.py
+++ b/worlds/manual_outerwilds_nicopopxd/__init__.py
@@ -149,9 +149,6 @@ class ManualWorld(World):
                 if name not in self.multiworld.local_items[self.player].value:
                     self.multiworld.local_items[self.player].value.add(name)
 
-        localtmp = self.multiworld.local_items[self.player]
-        localearlytmp = self.multiworld.local_early_items[self.player]
-        earlytmp = self.multiworld.early_items[self.player]
         items_started = []
 
         if starting_items:

--- a/worlds/manual_outerwilds_nicopopxd/__init__.py
+++ b/worlds/manual_outerwilds_nicopopxd/__init__.py
@@ -136,6 +136,22 @@ class ManualWorld(World):
                 new_item = self.create_item(name)
                 pool.append(new_item)
 
+            if item.get("early") and item.get("local"):
+              # both
+                self.multiworld.local_early_items[self.player][name] = item_count
+
+            elif item.get("early"):
+                # only early
+                self.multiworld.early_items[self.player][name] = item_count
+
+            elif item.get("local"):
+              # only local
+                if name not in self.multiworld.local_items[self.player].value:
+                    self.multiworld.local_items[self.player].value.add(name)
+
+        localtmp = self.multiworld.local_items[self.player]
+        localearlytmp = self.multiworld.local_early_items[self.player]
+        earlytmp = self.multiworld.early_items[self.player]
         items_started = []
 
         if starting_items:

--- a/worlds/manual_outerwilds_nicopopxd/data/game.json
+++ b/worlds/manual_outerwilds_nicopopxd/data/game.json
@@ -3,5 +3,5 @@
     "creator": "Nicopopxd",
 
     "filler_item_name": "Quantum dust",
-    "version": "5.4.1"
+    "version": "5.5.0"
 }

--- a/worlds/manual_outerwilds_nicopopxd/data/items.json
+++ b/worlds/manual_outerwilds_nicopopxd/data/items.json
@@ -41,6 +41,8 @@
     {
         "name": "Launch Codes",
         "progression": true,
+        "early": true,
+        "local":  true,
         "category": [ "Tools", "2a Not Trap" ]
     },
     {

--- a/worlds/manual_outerwilds_nicopopxd/data/locations.json
+++ b/worlds/manual_outerwilds_nicopopxd/data/locations.json
@@ -357,6 +357,8 @@
 	{
 		"name": "5 - Get through at least 2 nodes and get out alive",
 		"region": "Dark Bramble",
+		"requires": "(|Scout| and |Scout Photos|) or (|Signaloscope| and (|Signal > OW Ventures| or |Signal > Distress|))",
+		"_comment": "Added those requires because its not fun going in there blind",
 		"category": [ "5 - Dark Bramble" ]
 	},
 

--- a/worlds/manual_outerwilds_nicopopxd/hooks/World.py
+++ b/worlds/manual_outerwilds_nicopopxd/hooks/World.py
@@ -100,11 +100,11 @@ def after_create_regions(world: World, multiworld: MultiWorld, player: int):
 # Early Launch Codes
 #region
     early_launch = OWOptions[player]["early_launch_codes"]
-    if early_launch == EarlyLaunchCode.option_local:
-        multiworld.local_early_items[player]["Launch Codes"] = 1
+    if early_launch == EarlyLaunchCode.option_anywhere:
+        multiworld.local_early_items[player].pop("Launch Codes", "")
     elif early_launch == EarlyLaunchCode.option_global:
+        multiworld.local_early_items[player].pop("Launch Codes", "")
         multiworld.early_items[player]["Launch Codes"] = 1
-
 #endregion
     pass
 

--- a/worlds/manual_outerwilds_nicopopxd/hooks/World.py
+++ b/worlds/manual_outerwilds_nicopopxd/hooks/World.py
@@ -192,7 +192,7 @@ def before_generate_basic(item_pool: list, world: World, multiworld: MultiWorld,
 
     elif randomContent == RandomContent.option_dlc:
         worldlocation = world.location_name_to_location["Get in ship for the first time"]
-        RemovedPlacedItemsCategory[worldlocation.name] = copy(worldlocation["place_item_category"])
+        RemovedPlacedItemsCategory[worldlocation['name']] = copy(worldlocation["place_item_category"])
         worldlocation.pop("place_item_category", "")
 
         item_counts["forced Meditation"] = 3


### PR DESCRIPTION
## What is this fixing or adding?
- The fixes Fuzzy made to fixes the count/item_count deprecation
- Added some requirement to the "5 - Get through at least 2 nodes and get out alive"
  you now need any of the requirements of the existing locations in dark bramble "(|Scout| and |Scout Photos|) or (|Signaloscope| and (|Signal > OW Ventures| or |Signal > Distress|))"
  because "Added those requires because its not fun going in there blind"
- Implemented the local and early tag to items like I did in the [Manual PR 10](https://github.com/FuzzyGamesOn/Archipelago/pull/10)

## How was this tested?
The usual